### PR TITLE
feat.버튼 터치 영역 확대

### DIFF
--- a/Hodori.xcodeproj/project.pbxproj
+++ b/Hodori.xcodeproj/project.pbxproj
@@ -641,7 +641,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Hodori/Preview Content\"";
-				DEVELOPMENT_TEAM = 27567HRR46;
+				DEVELOPMENT_TEAM = HH4G2BS7C9;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Hodori/Info.plist;
@@ -664,7 +664,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Macro.Hodoris;
+				PRODUCT_BUNDLE_IDENTIFIER = Macro.Hodori29283;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -685,7 +685,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Hodori/Preview Content\"";
-				DEVELOPMENT_TEAM = 27567HRR46;
+				DEVELOPMENT_TEAM = HH4G2BS7C9;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Hodori/Info.plist;
@@ -708,7 +708,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Macro.Hodoris;
+				PRODUCT_BUNDLE_IDENTIFIER = Macro.Hodori29283;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Hodori/ContentView.swift
+++ b/Hodori/ContentView.swift
@@ -11,7 +11,7 @@ struct ContentView: View {
     @EnvironmentObject var navigationManager: NavigationManager
     
     var body: some View {
-        StartView()
+        StartView(meeting: Meeting(agendas: [.init(title: "", detail: [""])], startDate: Date()))
     }
 }
 

--- a/Hodori/Managers/NavigationManager.swift
+++ b/Hodori/Managers/NavigationManager.swift
@@ -28,7 +28,7 @@ extension AppScreen {
     var destination: some View {
         switch self {
         case .start:
-            StartView()
+            StartView(meeting: Meeting(agendas: [.init(title: "", detail: [""])], startDate: Date()))
         case .agendaSetting:
             AgendaSettingView()
 //        case .prioritySetting:

--- a/Hodori/Views/AgendaSetting/AgendaSettingView.swift
+++ b/Hodori/Views/AgendaSetting/AgendaSettingView.swift
@@ -82,7 +82,9 @@ struct AgendaSettingView: View {
                         isFocused.toggle()
                     } label: {
                         Image(systemName: "chevron.left")
-                            .foregroundStyle(.black)
+                            .frame(width: 50, height: 50, alignment: .leading)
+                            .foregroundStyle(Color.black)
+                            .font(.system(size: 17, weight: .semibold))
                     }
                 }
             }

--- a/Hodori/Views/History/HistoryDetailView.swift
+++ b/Hodori/Views/History/HistoryDetailView.swift
@@ -74,7 +74,9 @@ struct HistoryDetailView: View {
                             dismiss()
                         } label: {
                             Image(systemName: "chevron.left")
-                                .foregroundStyle(.black)
+                                .frame(width: 50, height: 50, alignment: .leading)
+                                .foregroundStyle(Color.black)
+                                .font(.system(size: 17, weight: .semibold))
                         }
                     }
                 }

--- a/Hodori/Views/History/HistoryView.swift
+++ b/Hodori/Views/History/HistoryView.swift
@@ -43,8 +43,9 @@ struct HistoryView: View {
                     VStack(alignment: .leading, spacing: 16) {
                         ForEach(Array(zip(meetings.indices, meetings)), id: \.1) { index, meeting in
                             yearSection(index)
+                        NavigationLink(destination: HistoryDetailView(meeting: meeting)) {
                             MeetingCard(.history, meeting: meeting)
-                            
+                            }
                         }
                     }
                     .padding(.horizontal, 24)

--- a/Hodori/Views/History/HistoryView.swift
+++ b/Hodori/Views/History/HistoryView.swift
@@ -32,7 +32,9 @@ struct HistoryView: View {
                                 navigationManager.screenPath.removeLast()
                             } label: {
                                 Image(systemName: "chevron.left")
-                                    .foregroundStyle(.black)
+                                    .frame(width: 50, height: 50, alignment: .leading)
+                                    .foregroundStyle(Color.black)
+                                    .font(.system(size: 17, weight: .semibold))
                             }
                         }
                     }
@@ -54,7 +56,9 @@ struct HistoryView: View {
                                 navigationManager.screenPath.removeLast()
                             } label: {
                                 Image(systemName: "chevron.left")
-                                    .foregroundStyle(.black)
+                                    .frame(width: 50, height: 50, alignment: .leading)
+                                    .foregroundStyle(Color.black)
+                                    .font(.system(size: 17, weight: .semibold))
                             }
                         }
                     }

--- a/Hodori/Views/MeetingView/MeetingView.swift
+++ b/Hodori/Views/MeetingView/MeetingView.swift
@@ -75,7 +75,7 @@ struct MeetingView: View {
                     showSheet = true
                 } label: {
                     Image(systemName: "list.bullet")
-                        .frame(width: 27, height: 22)
+                        .frame(width: 50, height: 50, alignment: .leading)
                         .foregroundStyle(Color.gray2)
                 }
                 .disabled(showAlert || showLottie)

--- a/Hodori/Views/PrioritySettingView/PrioritySettingView.swift
+++ b/Hodori/Views/PrioritySettingView/PrioritySettingView.swift
@@ -109,6 +109,7 @@ extension PrioritySettingView {
             dismiss()
         } label: {
             Image(systemName: "chevron.left")
+                .frame(width: 50, height: 50, alignment: .leading)
                 .foregroundStyle(Color.gray3)
                 .font(.system(size: 17, weight: .semibold))
                 .padding(.trailing, 30)

--- a/Hodori/Views/Start/MeetingCard.swift
+++ b/Hodori/Views/Start/MeetingCard.swift
@@ -76,15 +76,15 @@ struct MeetingCard: View {
             
             Spacer()
             
-            if cardState == .history {
-                NavigationLink {
-                    HistoryDetailView(meeting: meeting)
-                } label: {
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 16))
-                        .foregroundStyle(.black)
-                }
-            }
+//            if cardState == .history {
+//                NavigationLink {
+//                    HistoryDetailView(meeting: meeting)
+//                } label: {
+//                    Image(systemName: "chevron.right")
+//                        .font(.system(size: 16))
+//                        .foregroundStyle(.black)
+//                }
+//            }
         }
     }
     

--- a/Hodori/Views/Start/MeetingCard.swift
+++ b/Hodori/Views/Start/MeetingCard.swift
@@ -60,6 +60,7 @@ struct MeetingCard: View {
     }
     
     private var header: some View {
+        ZStack {
         HStack(spacing: 12) {
             PieChartView(agendas: Array(meeting.agendas))
                 .frame(width: 24, height: 24)
@@ -72,6 +73,7 @@ struct MeetingCard: View {
                 Text(cardState == .last ? fullDate : time)
                     .font(.pretendRegular14)
                     .foregroundStyle(Color.gray6)
+//                    .padding(.bottom, 1)
             }
             
             Spacer()
@@ -85,6 +87,15 @@ struct MeetingCard: View {
 //                        .foregroundStyle(.black)
 //                }
 //            }
+        }
+            HStack {
+                Spacer()
+                
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(.black)
+                    .padding(.top, 2)
+            }
         }
     }
     

--- a/Hodori/Views/Start/StartView.swift
+++ b/Hodori/Views/Start/StartView.swift
@@ -12,6 +12,13 @@ struct StartView: View {
     @EnvironmentObject var navigationManager: NavigationManager
     @State private var isHistoryNavigationButtonClicked = false
     @State private var isAgendaSettingNavigationButtonClicked = false
+    @State var tag:Int? = nil
+    
+    let meeting: Meeting
+
+    init(meeting: Meeting) {
+           self.meeting = meeting
+       }
     
     private var today: String {
         let currentDate = Date()
@@ -55,7 +62,20 @@ struct StartView: View {
                     .padding(.bottom, 40)
                 
                 if isMeetingExist {
-                    MeetingCard(.last, meeting: lastMeeting)
+                    Button(action: {
+                        self.tag = 1
+                    }) {
+                        MeetingCard(.last, meeting: lastMeeting)
+                    }
+                    .background(
+                        NavigationLink(
+                            destination: HistoryDetailView(meeting: meeting),
+                            tag: 1,
+                            selection: self.$tag
+                        ) {
+                            EmptyView()
+                        }
+                    )
                 } else {
                     placeholder
                 }
@@ -134,7 +154,7 @@ struct StartView: View {
 }
 
 #Preview {
-    StartView()
+    StartView(meeting: Meeting(agendas: [.init(title: "", detail: [""])], startDate: Date()))
         .environmentObject(MeetingManager())
         .environmentObject(NavigationManager())
 }

--- a/Hodori/Views/Start/StartView.swift
+++ b/Hodori/Views/Start/StartView.swift
@@ -69,7 +69,7 @@ struct StartView: View {
                     }
                     .background(
                         NavigationLink(
-                            destination: HistoryDetailView(meeting: meeting),
+                            destination: HistoryDetailView(meeting: lastMeeting), // lastMeeting 전달
                             tag: 1,
                             selection: self.$tag
                         ) {


### PR DESCRIPTION
- 앱 내부 쉐브론, 전체안건 버튼 터치영역 확대 구현.
- 스타트 뷰에 있는 직전회의기록 내역 박스 전체 터치시 직전회의기록 디테일뷰로 이동 구현.
- 히스튜리 뷰 미팅박스 전체를 터치영역으로 변경 구현.